### PR TITLE
Remove redundant "identifier" flag

### DIFF
--- a/src/handlers/auth-callback-request.js
+++ b/src/handlers/auth-callback-request.js
@@ -119,7 +119,6 @@ class AuthCallbackRequest {
     let webId = this.oidcManager.webIdFromClaims(claims)
 
     this.session.userId = webId
-    this.session.identified = true
   }
 
   /**

--- a/src/handlers/logout-request.js
+++ b/src/handlers/logout-request.js
@@ -51,7 +51,6 @@ class LogoutRequest {
     session.accessToken = ''
     session.refreshToken = ''
     session.userId = ''
-    session.identified = false
     session.subject = ''
   }
 

--- a/src/host-api.js
+++ b/src/host-api.js
@@ -68,13 +68,7 @@ function signalResponseSent () {
  * @return {string|null} Web ID of the authenticated user, or null
  */
 function authenticatedUser (authRequest) {
-  let session = authRequest.req.session
-
-  if (!session.identified || !session.userId) {
-    return null
-  }
-
-  return session.userId
+  return authRequest.req.session.userId || null
 }
 
 /**

--- a/test/unit/auth-callback-request.js
+++ b/test/unit/auth-callback-request.js
@@ -154,7 +154,6 @@ describe('AuthCallbackRequest', () => {
     expect(session.refreshToken).to.equal(refreshToken)
     expect(oidcManager.webIdFromClaims).to.have.been.calledWith(decodedClaims)
     expect(session.userId).to.equal(aliceWebId)
-    expect(session.identified).to.be.true()
   })
 
   describe('validateResponse()', () => {

--- a/test/unit/host-api-test.js
+++ b/test/unit/host-api-test.js
@@ -20,10 +20,10 @@ describe('Host API', () => {
       expect(api.authenticatedUser(authRequest)).to.be.null()
     })
 
-    it('should return true if session has user id and identified set', () => {
+    it('should return true if session has user id set', () => {
       let aliceWebId = 'https://alice.example.com/#me'
       let authRequest = {
-        req: { session: { userId: aliceWebId, identified: true } }
+        req: { session: { userId: aliceWebId } }
       }
 
       expect(api.authenticatedUser(authRequest)).to.equal(aliceWebId)
@@ -51,7 +51,7 @@ describe('Host API', () => {
 
     it('should initialize subject claim and return request if user is logged in', () => {
       let aliceWebId = 'https://alice.example.com/#me'
-      let session = { userId: aliceWebId, identified: true }
+      let session = { userId: aliceWebId }
       let authRequest = {
         req: HttpMocks.createRequest({ session }),
         res: HttpMocks.createResponse(),

--- a/test/unit/logout-request.js
+++ b/test/unit/logout-request.js
@@ -13,7 +13,6 @@ describe('LogoutRequest', () => {
     let req = {
       session: {
         userId: 'https://alice.example.com/#me',
-        identified: true,
         accessToken: {},
         refreshToken: {},
         subject: {}


### PR DESCRIPTION
Identifier is true IFF `userId` is set.

The fact that this library relies on `identifier` being set is a blocker for removing that flag in https://github.com/solid/node-solid-server/pull/531#issuecomment-321564187.