### PR TITLE
Delete email record too, reject if not given

### DIFF
--- a/src/user-store.js
+++ b/src/user-store.js
@@ -204,8 +204,13 @@ class UserStore {
 
   deleteUser (user) {
     let userKey = UserStore.normalizeIdKey(user.id)
-
-    return this.backend.del('users', userKey)
+    var deletedEmail = Promise.reject(new Error('No email given'))
+    if (user.email) {
+      let emailKey = UserStore.normalizeEmailKey(user.email)
+      deletedEmail = this.backend.del('users-by-email', emailKey)
+    }
+    let deletedUser = this.backend.del('users', userKey)
+    return Promise.all([deletedEmail, deletedUser])
   }
 
   /**

--- a/src/user-store.js
+++ b/src/user-store.js
@@ -204,10 +204,12 @@ class UserStore {
 
   deleteUser (user) {
     let userKey = UserStore.normalizeIdKey(user.id)
-    var deletedEmail = Promise.reject(new Error('No email given'))
+    var deletedEmail
     if (user.email) {
       let emailKey = UserStore.normalizeEmailKey(user.email)
       deletedEmail = this.backend.del('users-by-email', emailKey)
+    } else {
+      deletedEmail = Promise.reject(new Error('No email given'))
     }
     let deletedUser = this.backend.del('users', userKey)
     return Promise.all([deletedEmail, deletedUser])

--- a/test/unit/user-store-test.js
+++ b/test/unit/user-store-test.js
@@ -220,13 +220,15 @@ describe('UserStore', () => {
       store = UserStore.from({ path: './db' })
     })
 
-    it('should call backend.del with normalized user id', () => {
+    it('should call backend.del with normalized user id and email', () => {
       let userId = 'alice.solidtest.space/profile/card#me'
+      let email = 'alice@example.com'
 
       store.backend.del = sinon.stub()
 
-      store.deleteUser({ id: userId })
+      store.deleteUser({ id: userId, email: email })
       expect(store.backend.del).to.have.been.calledWith('users', UserStore.normalizeIdKey(userId))
+      expect(store.backend.del).to.have.been.calledWith('users-by-email', UserStore.normalizeEmailKey(email))
     })
   })
 })

--- a/test/unit/user-store-test.js
+++ b/test/unit/user-store-test.js
@@ -4,6 +4,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 chai.use(dirtyChai)
 const expect = chai.expect
+const assert = chai.assert
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 chai.use(sinonChai)
@@ -226,9 +227,27 @@ describe('UserStore', () => {
 
       store.backend.del = sinon.stub()
 
-      store.deleteUser({ id: userId, email: email })
-      expect(store.backend.del).to.have.been.calledWith('users', UserStore.normalizeIdKey(userId))
-      expect(store.backend.del).to.have.been.calledWith('users-by-email', UserStore.normalizeEmailKey(email))
+      return store.deleteUser({ id: userId, email: email })
+        .then(() => {
+          expect(store.backend.del).to.have.been.calledWith('users', UserStore.normalizeIdKey(userId))
+          expect(store.backend.del).to.have.been.calledWith('users-by-email', UserStore.normalizeEmailKey(email))
+        })
+    })
+
+    it('should call backend.del with normalized user id but no email', () => {
+      let userId = 'alice.solidtest.space/profile/card#me'
+
+      store.backend.del = sinon.stub()
+
+      return store.deleteUser({ id: userId })
+        .then(() => {
+          expect(store.backend.del).to.have.been.calledWith('users', UserStore.normalizeIdKey(userId))
+          expect(store.backend.del).to.not.have.been.calledWith('users-by-email', UserStore.normalizeEmailKey())
+        })
+        .then(
+          () => Promise.reject(new Error('Expected method to reject.')),
+          err => assert.instanceOf(err, Error)
+        )
     })
   })
 })


### PR DESCRIPTION
I found that there was a record that was not deleted. This is somewhat problematic on the node-solid-server side of things, because we don't require an email address. So, this should work with the way that things are now, I think, but isn't a terribly general  solution. Please poke! :-)