### PR TITLE
Support for new token (oidc-auth-manager)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid/oidc-auth-manager",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1915,6 +1915,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3097,7 +3098,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/oidc-manager.js
+++ b/src/oidc-manager.js
@@ -254,6 +254,7 @@ class OidcManager {
   initRs () {
     let rsConfig = { // oidc-rs
       defaults: {
+        tokenTypesSupported: [ 'legacyPop', 'dpop' ],
         handleErrors: false,
         optional: true,
         query: true,


### PR DESCRIPTION
The support for new token effort contains the following PRs
 -  NSS (https://github.com/solid/node-solid-server/pull/1427)
 - oidc-auth-manager (https://github.com/solid/oidc-auth-manager/pull/48)
 - oidc-op (https://github.com/solid/oidc-op/pull/22)
 - oidc-rs (https://github.com/solid/oidc-rs/pull/5)