### PR TITLE
Give priority to oidcIssuer in WebID profile

### DIFF
--- a/src/preferred-provider.js
+++ b/src/preferred-provider.js
@@ -62,9 +62,9 @@ function providerExists (uri) {
  *  provider URI was found, reject with an error.
  */
 function discoverProviderFor (webId) {
-  return discoverFromHeaders(webId)
+  return discoverFromProfile(webId)
 
-    .then(providerFromHeaders => providerFromHeaders || discoverFromProfile(webId))
+    .then(providerFromProfile => providerFromProfile || discoverFromHeaders(webId))
 
     .then(providerUri => {
       validateProviderUri(providerUri, webId) // Throw an error if empty or invalid

--- a/test/resources/sample-webid-profile-with-oidc-issuer.js
+++ b/test/resources/sample-webid-profile-with-oidc-issuer.js
@@ -13,5 +13,7 @@ module.exports = `
     a schema:Person ;
 
     solid:account </> ;  # link to the account uri
-    pim:storage </> .    # root storage
+    pim:storage </> ;    # root storage
+
+    solid:oidcIssuer <https://provider.com> .
 `

--- a/test/unit/oidc-manager-test.js
+++ b/test/unit/oidc-manager-test.js
@@ -14,6 +14,8 @@ chai.should()
 
 const OidcManager = require('../../src/oidc-manager')
 
+const sampleProfileSrc = require('../resources/sample-webid-profile')
+
 describe('OidcManager', () => {
   afterEach(() => {
     nock.cleanAll()
@@ -253,6 +255,10 @@ describe('OidcManager', () => {
       }
 
       nock('https://example.com')
+        .get('/profile')
+        .reply(200, sampleProfileSrc)
+
+      nock('https://example.com')
         .options('/profile')
         .reply(204, 'No content', {
           Link: '<https://provider.com>; rel="http://openid.net/specs/connect/1.0/issuer"'
@@ -269,6 +275,10 @@ describe('OidcManager', () => {
         iss: 'https://provider.com',
         sub: 'https://example.com/profile#me'
       }
+
+      nock('https://example.com')
+        .get('/profile')
+        .reply(200, sampleProfileSrc)
 
       nock('https://example.com')
         .options('/profile')

--- a/test/unit/preferred-provider-test.js
+++ b/test/unit/preferred-provider-test.js
@@ -12,6 +12,7 @@ const expect = chai.expect
 const serverUri = 'https://example.com'
 
 const sampleProfileSrc = require('../resources/sample-webid-profile')
+const sampleProfileSrcWithOidcIssuer = require('../resources/sample-webid-profile-with-oidc-issuer')
 
 describe('preferred-provider.js', () => {
   afterEach(() => {
@@ -22,6 +23,10 @@ describe('preferred-provider.js', () => {
     const webId = 'https://example.com/#me'
 
     it('should extract and validate the provider uri from link rel header', () => {
+      nock('https://example.com')
+        .get('/')
+        .reply(200, sampleProfileSrc)
+
       nock(serverUri)
         .options('/')
         .reply(204, 'No content', {
@@ -35,6 +40,10 @@ describe('preferred-provider.js', () => {
     })
 
     it('should not drop the path from extracted provider uri', () => {
+      nock('https://example.com')
+        .get('/')
+        .reply(200, sampleProfileSrc)
+
       nock(serverUri)
         .options('/')
         .reply(204, 'No content', {
@@ -49,12 +58,8 @@ describe('preferred-provider.js', () => {
 
     it('should extract and validate the provider uri from the webid profile', () => {
       nock(serverUri)
-        .options('/')
-        .reply(204, 'No content')
-
-      nock(serverUri)
         .get('/')
-        .reply(200, sampleProfileSrc, {
+        .reply(200, sampleProfileSrcWithOidcIssuer, {
           'Content-Type': 'text/turtle'
         })
 
@@ -147,6 +152,10 @@ describe('preferred-provider.js', () => {
     })
 
     it('should discover preferred provider if no oidc capability at webid', () => {
+      nock('https://example.com')
+        .get('/profile')
+        .reply(200, sampleProfileSrc)
+
       nock('https://example.com')
         .head('/.well-known/openid-configuration')
         .reply(404)


### PR DESCRIPTION
Issue #36
To conform with WebID OIDC spec the authentication of the WebID should honor a solid:oidc:Issuer predicate in the user profile. This was not the case in the current implementation as the http://openid.net/specs/connect/1.0/issuer link header in the OPTIONS response is always present and took priority over the predicate in the profile.